### PR TITLE
Update pickletools.py documentation

### DIFF
--- a/Lib/pickletools.py
+++ b/Lib/pickletools.py
@@ -1253,7 +1253,7 @@ opcodes = [
       stack_before=[],
       stack_after=[pyint],
       proto=2,
-      doc="""Long integer using found-byte length.
+      doc="""Long integer using four-byte length.
 
       A more efficient encoding of a Python long; the long4 encoding
       says it all."""),


### PR DESCRIPTION
Switching "found-byte" to "four-byte", fixing a typo.

```
gh-115146
```