### PR TITLE
Fix reference leak in _pickle.c's load_build

### DIFF
--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -6730,6 +6730,7 @@ load_build(PickleState *st, UnpicklerObject *self)
             }
             if (PyObject_SetItem(dict, d_key, d_value) < 0) {
                 Py_DECREF(d_key);
+                Py_DECREF(dict);
                 goto error;
             }
             Py_DECREF(d_key);


### PR DESCRIPTION
# Reference leak in `load_build` of `_pickle.c`

If PyObject_SetItem() fails in the `load_build()` function of _pickle.c, no DECREF for the `dict` variable
